### PR TITLE
Add priority handling to single threaded schedulers

### DIFF
--- a/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
+++ b/src/main/java/org/threadly/concurrent/AbstractPriorityScheduler.java
@@ -17,17 +17,21 @@ import org.threadly.util.Clock;
 import org.threadly.util.ExceptionUtils;
 
 /**
- * <p>Abstract implementation for implementations of {@link PrioritySchedulerInterface}.  This likely 
- * is not useful to many people outside of threadly, and is thus why it is package protected 
- * visibility.</p>
+ * <p>Abstract implementation for implementations of {@link PrioritySchedulerService}.  In 
+ * general this wont be useful outside of Threadly developers, but must be a public interface 
+ * since it is used in sub-packages.</p>
+ * 
+ * <p>If you do find yourself using this class, please post an issue on github to tell us why.  If 
+ * there is something you want our schedulers to provide, we are happy to hear about it.</p>
  * 
  * @author jent - Mike Jensen
  * @since 4.3.0
  */
 @SuppressWarnings("deprecation")
-abstract class AbstractPriorityScheduler extends AbstractSubmitterScheduler 
-                                         implements PrioritySchedulerInterface {
+public abstract class AbstractPriorityScheduler extends AbstractSubmitterScheduler 
+                                                implements PrioritySchedulerInterface {
   protected static final TaskPriority DEFAULT_PRIORITY = TaskPriority.High;
+  protected static final int DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS = 500;
   // tuned for performance of scheduled tasks
   protected static final int QUEUE_FRONT_PADDING = 0;
   protected static final int QUEUE_REAR_PADDING = 2;
@@ -42,11 +46,22 @@ abstract class AbstractPriorityScheduler extends AbstractSubmitterScheduler
   }
   
   /**
+   * Changes the max wait time for low priority tasks.  This is the amount of time that a low 
+   * priority task will wait if there are ready to execute high priority tasks.  After a low 
+   * priority task has waited this amount of time, it will be executed fairly with high priority 
+   * tasks (meaning it will only execute the high priority task if it has been waiting longer than 
+   * the low priority task).
+   * 
+   * @param maxWaitForLowPriorityInMs new wait time in milliseconds for low priority tasks during thread contention
+   */
+  public abstract void setMaxWaitForLowPriority(long maxWaitForLowPriorityInMs);
+  
+  /**
    * If a section of code wants a different default priority, or wanting to provide a specific 
    * default priority in for {@link KeyDistributedExecutor}, or {@link KeyDistributedScheduler}.
    * 
-   * @param priority default priority for PrioritySchedulerInterface implementation
-   * @return a PrioritySchedulerInterface with the default priority specified
+   * @param priority default priority for {@link PrioritySchedulerService} implementation
+   * @return a {@link PrioritySchedulerService} with the default priority specified
    */
   public PrioritySchedulerInterface makeWithDefaultPriority(TaskPriority priority) {
     if (priority == defaultPriority) {
@@ -76,7 +91,9 @@ abstract class AbstractPriorityScheduler extends AbstractSubmitterScheduler
    * @param priority Priority for task execution
    * @return Wrapper that was scheduled
    */
-  protected abstract TaskWrapper doSchedule(Runnable task, long delayInMillis, TaskPriority priority);
+  protected abstract OneTimeTaskWrapper doSchedule(Runnable task, 
+                                                   long delayInMillis, 
+                                                   TaskPriority priority);
 
   @Override
   public void execute(Runnable task, TaskPriority priority) {
@@ -154,6 +171,47 @@ abstract class AbstractPriorityScheduler extends AbstractSubmitterScheduler
   public void scheduleAtFixedRate(Runnable task, long initialDelay, long period) {
     scheduleAtFixedRate(task, initialDelay, period, null);
   }
+
+  protected static TaskWrapper getNextTask(QueueSet highPriorityQueueSet, QueueSet lowPriorityQueueSet, 
+                                           long maxWaitForLowPriorityInMs) {
+    TaskWrapper nextHighPriorityTask = highPriorityQueueSet.getNextTask();
+    TaskWrapper nextLowPriorityTask = lowPriorityQueueSet.getNextTask();
+    if (nextLowPriorityTask == null) {
+      return nextHighPriorityTask;
+    } else if (nextHighPriorityTask == null) {
+      return nextLowPriorityTask;
+    } else if (nextHighPriorityTask.getRunTime() <= nextLowPriorityTask.getRunTime()) {
+      return nextHighPriorityTask;
+    } else if (nextHighPriorityTask.getScheduleDelay() > 0 || 
+        // before the above check we know the low priority has been waiting longer than the high 
+        // priority, but since the high priority is not ready to run, we can just return the low 
+        // priority a clock call was invoked IF the high priority task was not already known to 
+        // be ready to run
+        //
+        // OR
+        //
+        // at this point we know the high task is ready to run
+        // but the low priority task has been waiting LONGER (and thus also ready to run)
+        // So we will return the low priority task IF it has been waiting over the max wait time
+        // At this point there may or may not have been a single clock invocation to check if the 
+        // high priority task was ready (if it was known ready, none was invoked)
+        // because of that we _may_ have to invoke the clock here
+        Clock.lastKnownForwardProgressingMillis() - nextLowPriorityTask.getRunTime() > maxWaitForLowPriorityInMs || 
+        Clock.accurateForwardProgressingMillis() - nextLowPriorityTask.getRunTime() > maxWaitForLowPriorityInMs) {
+      return nextLowPriorityTask;
+    } else {
+      // task is ready to run, low priority is also ready, but has not been waiting long enough
+      return nextHighPriorityTask;
+    }
+  }
+
+  /**
+   * Returns the {@link QueueSet} for a specified priority.
+   * 
+   * @param priority Priority that should match to the given {@link QueueSet}
+   * @return {@link QueueSet} which matches to the priority
+   */
+  protected abstract QueueSet getQueueSet(TaskPriority priority);
   
   /**
    * <p>Interface to be notified when relevant changes happen to the queue set.</p>

--- a/src/main/java/org/threadly/concurrent/AbstractSubmitterExecutor.java
+++ b/src/main/java/org/threadly/concurrent/AbstractSubmitterExecutor.java
@@ -13,6 +13,9 @@ import org.threadly.util.ArgumentVerifier;
  * of how this is used.  In general this wont be useful outside of Threadly developers, but must 
  * be a public interface since it is used in sub-packages.</p>
  * 
+ * <p>If you do find yourself using this class, please post an issue on github to tell us why.  If 
+ * there is something you want our schedulers to provide, we are happy to hear about it.</p>
+ * 
  * @author jent - Mike Jensen
  * @since 1.3.0
  */

--- a/src/main/java/org/threadly/concurrent/AbstractSubmitterScheduler.java
+++ b/src/main/java/org/threadly/concurrent/AbstractSubmitterScheduler.java
@@ -13,6 +13,9 @@ import org.threadly.util.ArgumentVerifier;
  * useful outside of Threadly developers, but must be a public interface since it is used in 
  * sub-packages.</p>
  * 
+ * <p>If you do find yourself using this class, please post an issue on github to tell us why.  If 
+ * there is something you want our schedulers to provide, we are happy to hear about it.</p>
+ * 
  * @author jent - Mike Jensen
  * @since 2.0.0
  */

--- a/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
+++ b/src/main/java/org/threadly/concurrent/NoThreadScheduler.java
@@ -28,7 +28,11 @@ import org.threadly.util.ExceptionUtils;
  */
 public class NoThreadScheduler extends AbstractPriorityScheduler {
   protected final Object taskNotifyLock;
-  protected final QueueSet queueSet;
+  protected final QueueSet highPriorityQueueSet;
+  protected final QueueSet lowPriorityQueueSet;
+  private final QueueSetListener queueListener;
+  private volatile long maxWaitForLowPriorityInMs;
+  private volatile boolean tickRunning;
   private volatile boolean currentlyBlocking;
   private volatile boolean tickCanceled;
   
@@ -36,10 +40,20 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * Constructs a new {@link NoThreadScheduler} scheduler.
    */
   public NoThreadScheduler() {
-    super(null);
+    this(null, DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS);
+  }
+  
+  /**
+   * Constructs a new {@link NoThreadScheduler} scheduler.
+   * 
+   * @param defaultPriority Default priority for tasks which are submitted without any specified priority
+   * @param maxWaitForLowPriorityInMs time low priority tasks to wait if there are high priority tasks ready to run
+   */
+  public NoThreadScheduler(TaskPriority defaultPriority, long maxWaitForLowPriorityInMs) {
+    super(defaultPriority);
     
     taskNotifyLock = new Object();
-    queueSet = new QueueSet(new QueueSetListener() {
+    queueListener = new QueueSetListener() {
       @Override
       public void handleQueueUpdate() {
         /* This is an optimization as we only need to synchronize and notify if there is a blocking 
@@ -57,9 +71,37 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
           }
         }
       }
-    });
+    };
+    highPriorityQueueSet = new QueueSet(queueListener);
+    lowPriorityQueueSet = new QueueSet(queueListener);
+    tickRunning = false;
     currentlyBlocking = false;
     tickCanceled = false;
+    
+    // call to verify and set values
+    setMaxWaitForLowPriority(maxWaitForLowPriorityInMs);
+  }
+  
+  @Override
+  public void setMaxWaitForLowPriority(long maxWaitForLowPriorityInMs) {
+    ArgumentVerifier.assertNotNegative(maxWaitForLowPriorityInMs, "maxWaitForLowPriorityInMs");
+    
+    this.maxWaitForLowPriorityInMs = maxWaitForLowPriorityInMs;
+  }
+  
+  
+  @Override
+  public long getMaxWaitForLowPriority() {
+    return maxWaitForLowPriorityInMs;
+  }
+  
+  @Override
+  protected QueueSet getQueueSet(TaskPriority priority) {
+    if (priority == TaskPriority.High) {
+      return highPriorityQueueSet;
+    } else {
+      return lowPriorityQueueSet;
+    }
   }
 
   /**
@@ -88,7 +130,7 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
   public void cancelTick() {
     tickCanceled = true;
     
-    queueSet.queueListener.handleQueueUpdate();
+    queueListener.handleQueueUpdate();
   }
   
   /**
@@ -107,7 +149,8 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * 
    * This call is NOT thread safe, calling {@link #tick(ExceptionHandler)} or 
    * {@link #blockingTick(ExceptionHandler)} in parallel could cause the same task to be 
-   * run multiple times in parallel.
+   * run multiple times in parallel.  Invoking in parallel will also make the behavior of 
+   * {@link #getCurrentRunningCount()} non-deterministic and inaccurate.
    * 
    * @since 3.2.0
    * 
@@ -133,29 +176,34 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
   private int tick(ExceptionHandler exceptionHandler, boolean resetCancelTickIfNoTasksRan) {
     int tasks = 0;
     TaskWrapper nextTask;
-    while ((nextTask = getNextReadyTask()) != null && ! tickCanceled) {
-      // call will remove task from queue, or reposition as necessary
-      if (nextTask.canExecute()) {
-        try {
-          nextTask.runTask();
-        } catch (Throwable t) {
-          if (exceptionHandler != null) {
-            exceptionHandler.handleException(t);
-          } else {
-            throw ExceptionUtils.makeRuntime(t);
+    tickRunning = true;
+    try {
+      while ((nextTask = getNextReadyTask()) != null && ! tickCanceled) {
+        // call will remove task from queue, or reposition as necessary
+        if (nextTask.canExecute()) {
+          try {
+            nextTask.runTask();
+          } catch (Throwable t) {
+            if (exceptionHandler != null) {
+              exceptionHandler.handleException(t);
+            } else {
+              throw ExceptionUtils.makeRuntime(t);
+            }
           }
+          
+          tasks++;
         }
-        
-        tasks++;
       }
+      
+      if ((tasks != 0 || resetCancelTickIfNoTasksRan) && tickCanceled) {
+        // reset for future tick calls
+        tickCanceled = false;
+      }
+      
+      return tasks;
+    } finally {
+      tickRunning = false;
     }
-    
-    if ((tasks != 0 || resetCancelTickIfNoTasksRan) && tickCanceled) {
-      // reset for future tick calls
-      tickCanceled = false;
-    }
-    
-    return tasks;
   }
   
   /**
@@ -176,7 +224,8 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * 
    * This call is NOT thread safe, calling {@link #tick(ExceptionHandler)} or 
    * {@link #blockingTick(ExceptionHandler)} in parallel could cause the same task to be 
-   * run multiple times in parallel.
+   * run multiple times in parallel.  Invoking in parallel will also make the behavior of 
+   * {@link #getCurrentRunningCount()} non-deterministic and inaccurate.
    * 
    * @since 4.0.0
    * 
@@ -199,7 +248,9 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
               tickCanceled = false;
               return 0;
             }
-            TaskWrapper nextTask = queueSet.getNextTask();
+            TaskWrapper nextTask = getNextTask(highPriorityQueueSet, 
+                                               lowPriorityQueueSet, 
+                                               maxWaitForLowPriorityInMs);
             if (nextTask == null) {
               taskNotifyLock.wait();
             } else {
@@ -225,7 +276,7 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
 
   @Override
   protected OneTimeTaskWrapper doSchedule(Runnable task, long delayInMillis, TaskPriority priority) {
-    // TODO - handle priority
+    QueueSet queueSet = getQueueSet(priority);
     OneTimeTaskWrapper result;
     if (delayInMillis == 0) {
       queueSet.addExecute((result = new NoThreadOneTimeTaskWrapper(task, queueSet.executeQueue, 
@@ -243,8 +294,11 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(initialDelay, "initialDelay");
     ArgumentVerifier.assertNotNegative(recurringDelay, "recurringDelay");
+    if (priority == null) {
+      priority = defaultPriority;
+    }
     
-    // TODO - handle priority
+    QueueSet queueSet = getQueueSet(priority);
     
     NoThreadRecurringDelayTaskWrapper taskWrapper = 
         new NoThreadRecurringDelayTaskWrapper(task, queueSet, 
@@ -258,8 +312,11 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
     ArgumentVerifier.assertNotNull(task, "task");
     ArgumentVerifier.assertNotNegative(initialDelay, "initialDelay");
     ArgumentVerifier.assertGreaterThanZero(period, "period");
+    if (priority == null) {
+      priority = defaultPriority;
+    }
     
-    // TODO - handle priority
+    QueueSet queueSet = getQueueSet(priority);
     
     NoThreadRecurringRateTaskWrapper taskWrapper = 
         new NoThreadRecurringRateTaskWrapper(task, queueSet, 
@@ -269,12 +326,17 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
   
   @Override
   public boolean remove(Runnable task) {
-    return queueSet.remove(task);
+    return highPriorityQueueSet.remove(task) || lowPriorityQueueSet.remove(task);
   }
   
   @Override
   public boolean remove(Callable<?> task) {
-    return queueSet.remove(task);
+    return highPriorityQueueSet.remove(task) || lowPriorityQueueSet.remove(task);
+  }
+
+  @Override
+  public int getCurrentRunningCount() {
+    return tickRunning ? 1 : 0;
   }
 
   @Override
@@ -293,7 +355,9 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * @return next ready task, or {@code null} if there are none
    */
   protected TaskWrapper getNextReadyTask() {
-    TaskWrapper tw = queueSet.getNextTask();
+    TaskWrapper tw = getNextTask(highPriorityQueueSet, 
+                                 lowPriorityQueueSet, 
+                                 maxWaitForLowPriorityInMs);
     if (tw != null && tw.getScheduleDelay() <= 0) {
       return tw;
     } else {
@@ -314,6 +378,10 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * @return {@code true} if there are task waiting to run
    */
   public boolean hasTaskReadyToRun() {
+    return hasTaskReadyToRun(highPriorityQueueSet) || hasTaskReadyToRun(lowPriorityQueueSet);
+  }
+  
+  private static boolean hasTaskReadyToRun(QueueSet queueSet) {
     if (queueSet.executeQueue.isEmpty()) {
       TaskWrapper headTask = queueSet.scheduleQueue.peekFirst();
       return headTask != null && headTask.getScheduleDelay() <= 0;
@@ -332,8 +400,10 @@ public class NoThreadScheduler extends AbstractPriorityScheduler {
    * @return List of runnables which were waiting in the task queue to be executed (and were now removed)
    */
   public List<Runnable> clearTasks() {
-    ArrayList<TaskWrapper> wrapperList = new ArrayList<TaskWrapper>(queueSet.queueSize());
-    queueSet.drainQueueInto(wrapperList);
+    ArrayList<TaskWrapper> wrapperList = new ArrayList<TaskWrapper>(highPriorityQueueSet.queueSize() + 
+                                                                    lowPriorityQueueSet.queueSize());
+    highPriorityQueueSet.drainQueueInto(wrapperList);
+    lowPriorityQueueSet.drainQueueInto(wrapperList);
     wrapperList.trimToSize();
     
     return ContainerHelper.getContainedRunnables(wrapperList);

--- a/src/main/java/org/threadly/concurrent/PriorityScheduler.java
+++ b/src/main/java/org/threadly/concurrent/PriorityScheduler.java
@@ -43,10 +43,7 @@ import org.threadly.util.ExceptionUtils;
  * @since 2.2.0 (existed since 1.0.0 as PriorityScheduledExecutor)
  */
 public class PriorityScheduler extends AbstractPriorityScheduler {
-  protected static final int DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS = 500;
   protected static final boolean DEFAULT_NEW_THREADS_DAEMON = true;
-  protected static final int WORKER_CONTENTION_LEVEL = 2; // level at which no worker contention is considered
-  protected static final int LOW_PRIORITY_WAIT_TOLLERANCE_IN_MS = 2;
   
   protected final WorkerPool workerPool;
   protected final QueueManager taskConsumer;
@@ -81,7 +78,7 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
    * will be scheduled as.  As well as the maximum wait for low priority tasks.
    * 
    * @param poolSize Thread pool size that should be maintained
-   * @param defaultPriority priority to give tasks which do not specify it
+   * @param defaultPriority Default priority for tasks which are submitted without any specified priority
    * @param maxWaitForLowPriorityInMs time low priority tasks to wait if there are high priority tasks ready to run
    */
   public PriorityScheduler(int poolSize, TaskPriority defaultPriority, 
@@ -95,7 +92,7 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
    * will be scheduled as.  As well as the maximum wait for low priority tasks.
    * 
    * @param poolSize Thread pool size that should be maintained
-   * @param defaultPriority priority to give tasks which do not specify it
+   * @param defaultPriority Default priority for tasks which are submitted without any specified priority
    * @param maxWaitForLowPriorityInMs time low priority tasks to wait if there are high priority tasks ready to run
    * @param useDaemonThreads {@code true} if newly created threads should be daemon
    */
@@ -113,7 +110,7 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
    * will be scheduled as.  As well as the maximum wait for low priority tasks.
    * 
    * @param poolSize Thread pool size that should be maintained
-   * @param defaultPriority priority to give tasks which do not specify it
+   * @param defaultPriority Default priority for tasks which are submitted without any specified priority
    * @param maxWaitForLowPriorityInMs time low priority tasks to wait if there are high priority tasks ready to run
    * @param threadFactory thread factory for producing new threads within executor
    */
@@ -169,6 +166,7 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
    * 
    * @return current number of running tasks
    */
+  @Override
   public int getCurrentRunningCount() {
     return workerPool.getCurrentRunningCount();
   }
@@ -190,25 +188,12 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
     workerPool.setPoolSize(newPoolSize);
   }
   
-  /**
-   * Changes the max wait time for low priority tasks.  This is the amount of time that a low 
-   * priority task will wait if there are ready to execute high priority tasks.  After a low 
-   * priority task has waited this amount of time, it will be executed fairly with high priority 
-   * tasks (meaning it will only execute the high priority task if it has been waiting longer than 
-   * the low priority task).
-   * 
-   * @param maxWaitForLowPriorityInMs new wait time in milliseconds for low priority tasks during thread contention
-   */
+  @Override
   public void setMaxWaitForLowPriority(long maxWaitForLowPriorityInMs) {
     taskConsumer.setMaxWaitForLowPriority(maxWaitForLowPriorityInMs);
   }
   
-  /**
-   * Getter for the amount of time a low priority task will wait during thread contention before 
-   * it is eligible for execution.
-   * 
-   * @return currently set max wait for low priority task
-   */
+  @Override
   public long getMaxWaitForLowPriority() {
     return taskConsumer.getMaxWaitForLowPriority();
   }
@@ -440,6 +425,11 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
     // shutdown the thread pool so we don't leak threads if garbage collected
     shutdown();
   }
+
+  @Override
+  protected QueueSet getQueueSet(TaskPriority priority) {
+    return taskConsumer.getQueueSet(priority);
+  }
   
   /**
    * <p>A service which manages the execute queues.  It runs a task to consume from the queues and 
@@ -573,65 +563,16 @@ public class PriorityScheduler extends AbstractPriorityScheduler {
      */
     protected TaskWrapper getNextReadyTask() throws InterruptedException {
       while (runningThread != null) {  // loop till we have something to return
-        TaskWrapper nextHighPriorityTask = highPriorityQueueSet.getNextTask();
-        TaskWrapper nextLowPriorityTask = lowPriorityQueueSet.getNextTask();
-        if (nextLowPriorityTask == null) {
-          if (nextHighPriorityTask == null) {
-            // no tasks, so just wait till any tasks come in
-            LockSupport.park();
-          } else {
-            // only high priority task is queued, so run if ready
-            long nextTaskDelay = nextHighPriorityTask.getScheduleDelay();
-            if (nextTaskDelay > 0) {
-              LockSupport.parkNanos(Clock.NANOS_IN_MILLISECOND * nextTaskDelay);
-            } else if (nextHighPriorityTask.canExecute()) {
-              return nextHighPriorityTask;
-            }
-          }
-        } else if (nextHighPriorityTask == null) {
-          // only low priority task is queued, so run if ready
-          long nextTaskDelay = nextLowPriorityTask.getScheduleDelay();
-          if (nextTaskDelay > 0) {
-            LockSupport.parkNanos(Clock.NANOS_IN_MILLISECOND * nextTaskDelay);
-          } else if (nextLowPriorityTask.canExecute()) {
-            return nextLowPriorityTask;
-          }
-        } else if (nextHighPriorityTask.getRunTime() <= nextLowPriorityTask.getRunTime()) {
-          // through cheap check we can see the high priority has been waiting longer
-          long nextTaskDelay = nextHighPriorityTask.getScheduleDelay();
-          if (nextTaskDelay > 0) {
-            LockSupport.parkNanos(Clock.NANOS_IN_MILLISECOND * nextTaskDelay);
-          } else if (nextHighPriorityTask.canExecute()) {
-            return nextHighPriorityTask;
-          }
+        TaskWrapper nextTask = getNextTask(highPriorityQueueSet, lowPriorityQueueSet, 
+                                           maxWaitForLowPriorityInMs);
+        if (nextTask == null) {
+          LockSupport.park();
         } else {
-          // both tasks are available, so see which one makes sense to run
-          long now = Clock.accurateForwardProgressingMillis();
-          // at this point we know nextHighDelay > nextLowDelay due to check above
-          long nextHighDelay = nextHighPriorityTask.getRunTime() - now;
-          long nextLowDelay = nextLowPriorityTask.getRunTime() - now;
-          if (nextHighDelay <= 0) {
-            /* high task is ready, make sure it should be picked...we will pick the low priority task 
-             * if it has been waiting longer than the high, and if the low priority has been waiting at 
-             * least the max wait time...otherwise we favor the high priority task
-             */
-            if (nextLowDelay < maxWaitForLowPriorityInMs * -1) {
-              if (nextLowPriorityTask.canExecute()) {
-                return nextLowPriorityTask;
-              }
-            } else if (nextHighPriorityTask.canExecute()) {
-              return nextHighPriorityTask;
-            }
-          } else if (nextLowDelay <= 0) {
-            if (nextLowPriorityTask.canExecute()) {
-              return nextLowPriorityTask;
-            }
-          } else {
-            if (nextLowDelay < nextHighDelay) {
-              LockSupport.parkNanos(Clock.NANOS_IN_MILLISECOND * nextLowDelay);
-            } else {
-              LockSupport.parkNanos(Clock.NANOS_IN_MILLISECOND * nextHighDelay);
-            }
+          long nextTaskDelay = nextTask.getScheduleDelay();
+          if (nextTaskDelay > 0) {
+            LockSupport.parkNanos(Clock.NANOS_IN_MILLISECOND * nextTaskDelay);
+          } else if (nextTask.canExecute()) {
+            return nextTask;
           }
         }
         

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerService.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerService.java
@@ -159,4 +159,12 @@ public interface PrioritySchedulerService extends SchedulerServiceInterface {
    * @return the set default task priority
    */
   public TaskPriority getDefaultPriority();
+  
+  /**
+   * Getter for the amount of time a low priority task will wait during thread contention before 
+   * it is eligible for execution.
+   * 
+   * @return currently set max wait for low priority task
+   */
+  public long getMaxWaitForLowPriority();
 }

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerServiceWrapper.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerServiceWrapper.java
@@ -93,8 +93,7 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     task = new ThrowableHandlingRecurringRunnable(scheduler, task);
     
     ListenableRunnableFuture<Void> taskFuture = new ListenableFutureTask<Void>(true, task);
-    TaskPriority priority = pScheduler.getDefaultPriority();
-    QueueSet queueSet = pScheduler.taskConsumer.getQueueSet(priority);
+    QueueSet queueSet = pScheduler.taskConsumer.getQueueSet(pScheduler.getDefaultPriority());
     RecurringDelayTaskWrapper rdtw = 
         new RecurringDelayTaskWrapper(taskFuture, queueSet,
                                       Clock.accurateForwardProgressingMillis() + initialDelay, delayInMs);
@@ -111,8 +110,7 @@ public class PrioritySchedulerServiceWrapper extends AbstractExecutorServiceWrap
     task = new ThrowableHandlingRecurringRunnable(pScheduler, task);
     
     ListenableRunnableFuture<Void> taskFuture = new ListenableFutureTask<Void>(true, task);
-    TaskPriority priority = pScheduler.getDefaultPriority();
-    QueueSet queueSet = pScheduler.taskConsumer.getQueueSet(priority);
+    QueueSet queueSet = pScheduler.taskConsumer.getQueueSet(pScheduler.getDefaultPriority());
     RecurringRateTaskWrapper rrtw = 
         new RecurringRateTaskWrapper(taskFuture, queueSet,
                                      Clock.accurateForwardProgressingMillis() + initialDelay, periodInMillis);

--- a/src/main/java/org/threadly/concurrent/PrioritySchedulerWrapper.java
+++ b/src/main/java/org/threadly/concurrent/PrioritySchedulerWrapper.java
@@ -157,6 +157,16 @@ public class PrioritySchedulerWrapper implements PrioritySchedulerInterface {
   }
 
   @Override
+  public long getMaxWaitForLowPriority() {
+    return scheduler.getMaxWaitForLowPriority();
+  }
+
+  @Override
+  public int getCurrentRunningCount() {
+    return scheduler.getCurrentRunningCount();
+  }
+
+  @Override
   public boolean remove(Runnable task) {
     return scheduler.remove(task);
   }

--- a/src/main/java/org/threadly/concurrent/SchedulerService.java
+++ b/src/main/java/org/threadly/concurrent/SchedulerService.java
@@ -31,6 +31,13 @@ public interface SchedulerService extends SubmitterSchedulerInterface {
   public boolean remove(Callable<?> task);
   
   /**
+   * Call to check how many tasks are currently being executed in this scheduler.
+   * 
+   * @return current number of running tasks
+   */
+  public int getCurrentRunningCount();
+  
+  /**
    * Function to check if the thread pool is currently accepting and handling tasks.
    * 
    * @return {@code true} if thread pool is running

--- a/src/main/java/org/threadly/concurrent/limiter/PrioritySchedulerLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/PrioritySchedulerLimiter.java
@@ -182,6 +182,11 @@ public class PrioritySchedulerLimiter extends SchedulerServiceLimiter
     return scheduler.getDefaultPriority();
   }
 
+  @Override
+  public long getMaxWaitForLowPriority() {
+    return scheduler.getMaxWaitForLowPriority();
+  }
+
   /**
    * <p>Wrapper for recurring tasks that reschedule with a given delay after completing 
    * execution.</p>

--- a/src/main/java/org/threadly/concurrent/limiter/SchedulerServiceLimiter.java
+++ b/src/main/java/org/threadly/concurrent/limiter/SchedulerServiceLimiter.java
@@ -83,6 +83,11 @@ public class SchedulerServiceLimiter extends SimpleSchedulerLimiter
   }
 
   @Override
+  public int getCurrentRunningCount() {
+    return scheduler.getCurrentRunningCount();
+  }
+
+  @Override
   public boolean isShutdown() {
     return scheduler.isShutdown();
   }

--- a/src/main/java/org/threadly/test/concurrent/TestablePriorityScheduler.java
+++ b/src/main/java/org/threadly/test/concurrent/TestablePriorityScheduler.java
@@ -1,83 +1,18 @@
 package org.threadly.test.concurrent;
 
-import java.util.concurrent.Callable;
-
 import org.threadly.concurrent.PrioritySchedulerInterface;
-import org.threadly.concurrent.TaskPriority;
-import org.threadly.concurrent.future.ListenableFuture;
-
 /**
  * <p>This is similar to {@link TestableScheduler} except that it implements the 
  * {@link PrioritySchedulerInterface}.  This allows you to use a this testable implementation in 
  * code which requires a {@link PrioritySchedulerInterface}.</p>
  * 
- * <p>Since {@link TaskPriority} makes no sense for either a {@link TestableScheduler} due to the 
- * single threaded nature of it.  The priority in this implementation is simply ignored.  This is 
- * only provided to allow compatibility with the {@link PrioritySchedulerInterface}.</p>
+ * @deprecated Use {@link TestableScheduler} now that it also implements {@link PrioritySchedulerInterface}
  * 
  * @author jent - Mike Jensen
  * @since 3.4.0
  */
-@SuppressWarnings({ "deprecation", "javadoc" })
+@Deprecated
 public class TestablePriorityScheduler extends TestableScheduler 
                                        implements PrioritySchedulerInterface {
-  @Override
-  public void execute(Runnable task, TaskPriority priority) {
-    super.execute(task);
-  }
-
-  @Override
-  public ListenableFuture<?> submit(Runnable task, TaskPriority priority) {
-    return super.submit(task);
-  }
-
-  @Override
-  public <T> ListenableFuture<T> submit(Runnable task, T result, TaskPriority priority) {
-    return super.submit(task, result);
-  }
-
-  @Override
-  public <T> ListenableFuture<T> submit(Callable<T> task, TaskPriority priority) {
-    return super.submit(task);
-  }
-
-  @Override
-  public void schedule(Runnable task, long delayInMs, TaskPriority priority) {
-    super.schedule(task, delayInMs);
-  }
-
-  @Override
-  public ListenableFuture<?> submitScheduled(Runnable task, long delayInMs, 
-                                             TaskPriority priority) {
-    return super.submitScheduled(task, delayInMs);
-  }
-
-  @Override
-  public <T> ListenableFuture<T> submitScheduled(Runnable task, T result, long delayInMs,
-                                                 TaskPriority priority) {
-    return super.submitScheduled(task, result, delayInMs);
-  }
-
-  @Override
-  public <T> ListenableFuture<T> submitScheduled(Callable<T> task, long delayInMs,
-                                                 TaskPriority priority) {
-    return super.submitScheduled(task, delayInMs);
-  }
-
-  @Override
-  public void scheduleWithFixedDelay(Runnable task, long initialDelay, long recurringDelay,
-                                     TaskPriority priority) {
-    super.scheduleWithFixedDelay(task, initialDelay, recurringDelay);
-  }
-
-  @Override
-  public void scheduleAtFixedRate(Runnable task, long initialDelay, long period,
-                                  TaskPriority priority) {
-    super.scheduleAtFixedRate(task, initialDelay, period);
-  }
-
-  @Override
-  public TaskPriority getDefaultPriority() {
-    return TaskPriority.High;
-  }
+  // nothing added here
 }

--- a/src/test/java/org/threadly/concurrent/AbstractPrioritySchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/AbstractPrioritySchedulerTest.java
@@ -1,0 +1,375 @@
+package org.threadly.concurrent;
+
+import static org.junit.Assert.*;
+import static org.threadly.TestConstants.*;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+import org.threadly.BlockingTestRunnable;
+import org.threadly.test.concurrent.TestCondition;
+import org.threadly.test.concurrent.TestRunnable;
+import org.threadly.test.concurrent.TestUtils;
+
+@SuppressWarnings("javadoc")
+public abstract class AbstractPrioritySchedulerTest extends SchedulerServiceInterfaceTest {
+  @Override
+  protected SchedulerServiceFactory getSchedulerServiceFactory() {
+    return getAbstractPrioritySchedulerFactory();
+  }
+  
+  protected abstract AbstractPrioritySchedulerFactory getAbstractPrioritySchedulerFactory();
+  
+  @Test
+  public void getDefaultPriorityTest() {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    TaskPriority priority = TaskPriority.High;
+    try {
+      AbstractPriorityScheduler scheduler = factory.makeAbstractPriorityScheduler(1, priority, 1000);
+      
+      assertEquals(priority, scheduler.getDefaultPriority());
+      
+      priority = TaskPriority.Low;
+      scheduler = factory.makeAbstractPriorityScheduler(1, priority, 1000);
+      assertEquals(priority, scheduler.getDefaultPriority());
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Test
+  public void constructorNullPriorityTest() {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    try {
+      AbstractPriorityScheduler executor = factory.makeAbstractPriorityScheduler(1, null, 1);
+      
+      assertTrue(executor.getDefaultPriority() == AbstractPriorityScheduler.DEFAULT_PRIORITY);
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Test
+  public void makeWithDefaultPriorityTest() {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    TaskPriority originalPriority = TaskPriority.Low;
+    TaskPriority newPriority = TaskPriority.High;
+    AbstractPriorityScheduler scheduler = factory.makeAbstractPriorityScheduler(1, originalPriority, 1000);
+    assertTrue(scheduler.makeWithDefaultPriority(originalPriority) == scheduler);
+    PrioritySchedulerService newScheduler = scheduler.makeWithDefaultPriority(newPriority);
+    try {
+      assertEquals(newPriority, newScheduler.getDefaultPriority());
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Test
+  public void getAndSetLowPriorityWaitTest() {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    long lowPriorityWait = 1000;
+    AbstractPriorityScheduler scheduler = factory.makeAbstractPriorityScheduler(1, TaskPriority.High, lowPriorityWait);
+    try {
+      assertEquals(lowPriorityWait, scheduler.getMaxWaitForLowPriority());
+      
+      lowPriorityWait = Long.MAX_VALUE;
+      scheduler.setMaxWaitForLowPriority(lowPriorityWait);
+      
+      assertEquals(lowPriorityWait, scheduler.getMaxWaitForLowPriority());
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Test
+  public void setLowPriorityWaitFail() {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    long lowPriorityWait = 1000;
+    AbstractPriorityScheduler scheduler = factory.makeAbstractPriorityScheduler(1, TaskPriority.High, lowPriorityWait);
+    try {
+      try {
+        scheduler.setMaxWaitForLowPriority(-1);
+        fail("Exception should have thrown");
+      } catch (IllegalArgumentException e) {
+        // expected
+      }
+      
+      assertEquals(lowPriorityWait, scheduler.getMaxWaitForLowPriority());
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Test
+  public void getCurrentRunningCountTest() {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    final AbstractPriorityScheduler scheduler = factory.makeAbstractPriorityScheduler(1);
+    try {
+      // verify nothing at the start
+      assertEquals(0, scheduler.getCurrentRunningCount());
+      
+      BlockingTestRunnable btr = new BlockingTestRunnable();
+      scheduler.execute(btr);
+      
+      btr.blockTillStarted();
+      
+      assertEquals(1, scheduler.getCurrentRunningCount());
+      
+      btr.unblock();
+      
+      new TestCondition() {
+        @Override
+        public boolean get() {
+          return scheduler.getCurrentRunningCount() == 0;
+        }
+      }.blockTillTrue();
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Override
+  @Test
+  public void executeTest() {
+    AbstractPrioritySchedulerFactory priorityFactory = getAbstractPrioritySchedulerFactory();
+    try {
+      super.executeTest();
+
+      PrioritySchedulerService scheduler = priorityFactory.makeAbstractPriorityScheduler(2);
+      
+      TestRunnable tr1 = new TestRunnable();
+      TestRunnable tr2 = new TestRunnable();
+      scheduler.execute(tr1, TaskPriority.High);
+      scheduler.execute(tr2, TaskPriority.Low);
+      scheduler.execute(tr1, TaskPriority.High);
+      scheduler.execute(tr2, TaskPriority.Low);
+      
+      tr1.blockTillFinished(1000 * 10, 2); // throws exception if fails
+      tr2.blockTillFinished(1000 * 10, 2); // throws exception if fails
+    } finally {
+      priorityFactory.shutdown();
+    }
+  }
+  
+  @Override
+  @Test
+  public void submitRunnableTest() throws InterruptedException, ExecutionException {
+    AbstractPrioritySchedulerFactory priorityFactory = getAbstractPrioritySchedulerFactory();
+    try {
+      super.submitRunnableTest();
+      
+      PrioritySchedulerService scheduler = priorityFactory.makeAbstractPriorityScheduler(2);
+      
+      TestRunnable tr1 = new TestRunnable();
+      TestRunnable tr2 = new TestRunnable();
+      scheduler.submit(tr1, TaskPriority.High);
+      scheduler.submit(tr2, TaskPriority.Low);
+      scheduler.submit(tr1, TaskPriority.High);
+      scheduler.submit(tr2, TaskPriority.Low);
+      
+      tr1.blockTillFinished(1000 * 10, 2); // throws exception if fails
+      tr2.blockTillFinished(1000 * 10, 2); // throws exception if fails
+    } finally {
+      priorityFactory.shutdown();
+    }
+  }
+  
+  @Override
+  @Test
+  public void submitRunnableWithResultTest() throws InterruptedException, ExecutionException {
+    AbstractPrioritySchedulerFactory priorityFactory = getAbstractPrioritySchedulerFactory();
+    try {
+      super.submitRunnableWithResultTest();
+
+      PrioritySchedulerService scheduler = priorityFactory.makeAbstractPriorityScheduler(2);
+      
+      TestRunnable tr1 = new TestRunnable();
+      TestRunnable tr2 = new TestRunnable();
+      scheduler.submit(tr1, tr1, TaskPriority.High);
+      scheduler.submit(tr2, tr2, TaskPriority.Low);
+      scheduler.submit(tr1, tr1, TaskPriority.High);
+      scheduler.submit(tr2, tr2, TaskPriority.Low);
+      
+      tr1.blockTillFinished(1000 * 10, 2); // throws exception if fails
+      tr2.blockTillFinished(1000 * 10, 2); // throws exception if fails
+    } finally {
+      priorityFactory.shutdown();
+    }
+  }
+  
+  @Override
+  @Test
+  public void submitCallableTest() throws InterruptedException, ExecutionException {
+    AbstractPrioritySchedulerFactory priorityFactory = getAbstractPrioritySchedulerFactory();
+    try {
+      super.submitCallableTest();
+
+      PrioritySchedulerService scheduler = priorityFactory.makeAbstractPriorityScheduler(2);
+      
+      TestCallable tc1 = new TestCallable(0);
+      TestCallable tc2 = new TestCallable(0);
+      scheduler.submit(tc1, TaskPriority.High);
+      scheduler.submit(tc2, TaskPriority.Low);
+      
+      tc1.blockTillTrue(); // throws exception if fails
+      tc2.blockTillTrue(); // throws exception if fails
+    } finally {
+      priorityFactory.shutdown();
+    }
+  }
+  
+  @Test
+  public void lowPriorityFlowControlTest() {
+    AbstractPrioritySchedulerFactory priorityFactory = getAbstractPrioritySchedulerFactory();
+    final AtomicBoolean testRunning = new AtomicBoolean(true);
+    try {
+      final AbstractPriorityScheduler scheduler = priorityFactory.makeAbstractPriorityScheduler(1, TaskPriority.High, DELAY_TIME);
+      
+      new Runnable() {
+        @Override
+        public void run() {
+          if (testRunning.get()) {
+            while (scheduler.getQueueSet(TaskPriority.High).executeQueue.size() < 5) {
+              scheduler.execute(this, TaskPriority.High);
+            }
+          }
+        }
+      }.run();
+      
+      TestRunnable lowPriorityRunnable = new TestRunnable();
+      scheduler.execute(lowPriorityRunnable, TaskPriority.Low);
+      
+      assertTrue(lowPriorityRunnable.getDelayTillFirstRun() >= DELAY_TIME);
+    } finally {
+      testRunning.set(false);
+      priorityFactory.shutdown();
+    }
+  }
+  
+  @Test
+  public void removeHighPriorityRecurringRunnableTest() {
+    removeRecurringRunnableTest(TaskPriority.High);
+  }
+  
+  @Test
+  public void removeLowPriorityRecurringRunnableTest() {
+    removeRecurringRunnableTest(TaskPriority.Low);
+  }
+  
+  private void removeRecurringRunnableTest(TaskPriority priority) {
+    int runFrequency = 1;
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    try {
+      AbstractPriorityScheduler scheduler = factory.makeAbstractPriorityScheduler(1);
+      TestRunnable removedTask = new TestRunnable();
+      TestRunnable keptTask = new TestRunnable();
+      scheduler.scheduleWithFixedDelay(removedTask, 0, runFrequency, priority);
+      scheduler.scheduleWithFixedDelay(keptTask, 0, runFrequency, priority);
+      removedTask.blockTillStarted();
+      
+      assertFalse(scheduler.remove(new TestRunnable()));
+      
+      assertTrue(scheduler.remove(removedTask));
+      
+      // verify removed is no longer running, and the kept task continues to run
+      int keptRunCount = keptTask.getRunCount();
+      int runCount = removedTask.getRunCount();
+      TestUtils.sleep(runFrequency * 10);
+
+      // may be +1 if the task was running while the remove was called
+      assertTrue(removedTask.getRunCount() == runCount || 
+                 removedTask.getRunCount() == runCount + 1);
+      
+      assertTrue(keptTask.getRunCount() >= keptRunCount);
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Test
+  public void removeHighPriorityRunnableTest() {
+    removeRunnableTest(TaskPriority.High);
+  }
+  
+  @Test
+  public void removeLowPriorityRunnableTest() {
+    removeRunnableTest(TaskPriority.Low);
+  }
+  
+  private void removeRunnableTest(TaskPriority priority) {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    try {
+      AbstractPriorityScheduler scheduler = factory.makeAbstractPriorityScheduler(1);
+      TestRunnable removedTask = new TestRunnable();
+      scheduler.submitScheduled(removedTask, 10 * 1000, priority);
+      
+      assertFalse(scheduler.remove(new TestRunnable()));
+      
+      assertTrue(scheduler.remove(removedTask));
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Test
+  public void removeHighPriorityCallableTest() {
+    removeCallableTest(TaskPriority.High);
+  }
+  
+  @Test
+  public void removeLowPriorityCallableTest() {
+    removeCallableTest(TaskPriority.Low);
+  }
+  
+  private void removeCallableTest(TaskPriority priority) {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    try {
+      AbstractPriorityScheduler scheduler = factory.makeAbstractPriorityScheduler(1);
+      TestCallable task = new TestCallable();
+      scheduler.submitScheduled(task, 1000 * 10, priority);
+      
+      assertFalse(scheduler.remove(new TestCallable()));
+      
+      assertTrue(scheduler.remove(task));
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Test
+  public void wrapperSamePriorityTest() {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    try {
+      AbstractPriorityScheduler highPriorityScheduler = factory.makeAbstractPriorityScheduler(1, TaskPriority.High, 200);
+      assertTrue(highPriorityScheduler.makeWithDefaultPriority(TaskPriority.High) == highPriorityScheduler);
+      
+      AbstractPriorityScheduler lowPriorityScheduler = factory.makeAbstractPriorityScheduler(1, TaskPriority.Low, 200);
+      assertTrue(lowPriorityScheduler.makeWithDefaultPriority(TaskPriority.Low) == lowPriorityScheduler);
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  @Test
+  public void wrapperTest() {
+    AbstractPrioritySchedulerFactory factory = getAbstractPrioritySchedulerFactory();
+    try {
+      AbstractPriorityScheduler highPriorityScheduler = factory.makeAbstractPriorityScheduler(1, TaskPriority.High, 200);
+      assertTrue(highPriorityScheduler.makeWithDefaultPriority(TaskPriority.Low).getDefaultPriority() == TaskPriority.Low);
+      
+      AbstractPriorityScheduler lowPriorityScheduler = factory.makeAbstractPriorityScheduler(1, TaskPriority.Low, 200);
+      assertTrue(lowPriorityScheduler.makeWithDefaultPriority(TaskPriority.High).getDefaultPriority() == TaskPriority.High);
+    } finally {
+      factory.shutdown();
+    }
+  }
+  
+  public interface AbstractPrioritySchedulerFactory extends SchedulerServiceFactory {
+    public AbstractPriorityScheduler makeAbstractPriorityScheduler(int poolSize, 
+                                                                   TaskPriority defaultPriority, 
+                                                                   long maxWaitForLowPriority);
+    
+    public AbstractPriorityScheduler makeAbstractPriorityScheduler(int poolSize);
+  }
+}

--- a/src/test/java/org/threadly/concurrent/NoThreadSchedulerTest.java
+++ b/src/test/java/org/threadly/concurrent/NoThreadSchedulerTest.java
@@ -561,9 +561,10 @@ public class NoThreadSchedulerTest {
     // should no longer have anything to run
     assertFalse(scheduler.hasTaskReadyToRun());
     
-    scheduler.queueSet.addScheduled(new OneTimeTaskWrapper(DoNothingRunnable.instance(), 
-                                                           scheduler.queueSet.scheduleQueue, 
-                                                           Clock.lastKnownForwardProgressingMillis()));
+    scheduler.highPriorityQueueSet
+             .addScheduled(new OneTimeTaskWrapper(DoNothingRunnable.instance(), 
+                                                  scheduler.highPriorityQueueSet.scheduleQueue, 
+                                                  Clock.lastKnownForwardProgressingMillis()));
     
     // now should be true with scheduled task which is ready to run
     assertTrue(scheduler.hasTaskReadyToRun());
@@ -593,7 +594,7 @@ public class NoThreadSchedulerTest {
     
     scheduler.clearTasks();
     
-    assertEquals(0, scheduler.queueSet.executeQueue.size());
-    assertEquals(0, scheduler.queueSet.scheduleQueue.size());
+    assertEquals(0, scheduler.highPriorityQueueSet.queueSize());
+    assertEquals(0, scheduler.lowPriorityQueueSet.queueSize());
   }
 }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerQueueManagerTest.java
@@ -28,7 +28,7 @@ public class PrioritySchedulerQueueManagerTest {
     ConfigurableThreadFactory threadFactory = new ConfigurableThreadFactory();
     workerPool = new WorkerPool(threadFactory, 1);
     queueManager = new QueueManager(workerPool, THREAD_NAME, 
-                                    PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS) {
+                                    AbstractPriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS) {
       @Override
       protected void startupService() {
         // we override this so we can avoid starting threads in these tests
@@ -57,7 +57,7 @@ public class PrioritySchedulerQueueManagerTest {
     try {
       WorkerPool workerPool = new WorkerPool(threadFactory, 1);
       queueManager = new QueueManager(workerPool, THREAD_NAME, 
-                                      PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS);
+                                      AbstractPriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS);
     } finally {
       threadFactory.killThreads();
     }
@@ -245,7 +245,7 @@ public class PrioritySchedulerQueueManagerTest {
   
   @Test
   public void getAndSetLowPriorityWaitTest() {
-    assertEquals(PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, queueManager.getMaxWaitForLowPriority());
+    assertEquals(AbstractPriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, queueManager.getMaxWaitForLowPriority());
     
     long lowPriorityWait = Long.MAX_VALUE;
     queueManager.setMaxWaitForLowPriority(lowPriorityWait);
@@ -262,6 +262,6 @@ public class PrioritySchedulerQueueManagerTest {
       // expected
     }
     
-    assertEquals(PriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, queueManager.getMaxWaitForLowPriority());
+    assertEquals(AbstractPriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, queueManager.getMaxWaitForLowPriority());
   }
 }

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerStatisticTrackerTest.java
@@ -559,6 +559,18 @@ public class PrioritySchedulerStatisticTrackerTest extends PrioritySchedulerTest
     }
 
     @Override
+    public AbstractPriorityScheduler makeAbstractPriorityScheduler(int poolSize,
+                                                                   TaskPriority defaultPriority,
+                                                                   long maxWaitForLowPriority) {
+      return makePriorityScheduler(poolSize, defaultPriority, maxWaitForLowPriority);
+    }
+
+    @Override
+    public AbstractPriorityScheduler makeAbstractPriorityScheduler(int poolSize) {
+      return makePriorityScheduler(poolSize);
+    }
+
+    @Override
     public PriorityScheduler makePriorityScheduler(int poolSize, TaskPriority defaultPriority,
                                                    long maxWaitForLowPriority) {
       PriorityScheduler result = new PrioritySchedulerStatisticTracker(poolSize, defaultPriority, 

--- a/src/test/java/org/threadly/concurrent/PrioritySchedulerWrapperTest.java
+++ b/src/test/java/org/threadly/concurrent/PrioritySchedulerWrapperTest.java
@@ -311,6 +311,16 @@ public class PrioritySchedulerWrapperTest {
     public TaskPriority getDefaultPriority() {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public long getMaxWaitForLowPriority() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getCurrentRunningCount() {
+      throw new UnsupportedOperationException();
+    }
     
     // NO OPERATIONS WITHOUT PRIORITY SHOULD BE CALLED
     @Override

--- a/src/test/java/org/threadly/concurrent/SingleThreadSchedulerSchedulerManagerTest.java
+++ b/src/test/java/org/threadly/concurrent/SingleThreadSchedulerSchedulerManagerTest.java
@@ -9,7 +9,9 @@ import org.threadly.concurrent.SingleThreadScheduler.SchedulerManager;
 public class SingleThreadSchedulerSchedulerManagerTest {
   @Test
   public void constructorTest() {
-    SchedulerManager sm = new SchedulerManager(new ConfigurableThreadFactory());
+    SchedulerManager sm = new SchedulerManager(AbstractPriorityScheduler.DEFAULT_PRIORITY, 
+                                               AbstractPriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, 
+                                               new ConfigurableThreadFactory());
     
     assertNotNull(sm.scheduler);
     assertNotNull(sm.execThread);
@@ -20,7 +22,8 @@ public class SingleThreadSchedulerSchedulerManagerTest {
   public void constructorFail() {
     StartingThreadFactory threadFactory = new StartingThreadFactory();
     try {
-      new SchedulerManager(threadFactory);
+      new SchedulerManager(AbstractPriorityScheduler.DEFAULT_PRIORITY, 
+                           AbstractPriorityScheduler.DEFAULT_LOW_PRIORITY_MAX_WAIT_IN_MS, threadFactory);
     } finally {
       threadFactory.killThreads();
     }

--- a/src/test/java/org/threadly/test/concurrent/TestablePrioritySchedulerTest.java
+++ b/src/test/java/org/threadly/test/concurrent/TestablePrioritySchedulerTest.java
@@ -13,7 +13,7 @@ import org.threadly.concurrent.TaskPriority;
 import org.threadly.concurrent.future.ListenableFuture;
 import org.threadly.util.StringUtils;
 
-@SuppressWarnings("javadoc")
+@SuppressWarnings({"javadoc", "deprecation"})
 public class TestablePrioritySchedulerTest extends TestableSchedulerTest {
   protected TestablePriorityScheduler priorityScheduler;
   


### PR DESCRIPTION
This resolves #159.  In 4.0.0 our understanding of task priority changed, and it was no longer strictly related to how threads were spawned.  Now the logic makes sense even when there is only one thread consuming tasks.
This commit adds those concepts to NoThreadScheduler, SingleThreadScheduler, TestableScheduler (and thus deprecated TestablePriorityScheduler).

@lwahlmeier this PR is not on the main project because this builds on the previous work you already looked at in PR.  I still need to benchmark these changes as well, though I don't predict any issues.

This does increase the jar size again :-(

But I do like the idea that we would have priority support throughout ALL of the threadly schedulers with this change.  Let me know your thoughts (or any ideas you might have for code improvements).

Don't merge this, just let me know when you think it looks good